### PR TITLE
Add optional parser to Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Prompt {
     validator      = function(text)
         return text:match("[a-zA-Z]*"), "Message when not valid"
     end,
+    -- Similar to a validator, but can transform the result
+    parser         = function(text)
+        local v = tonumber(text)
+        if not v then
+            return nil, "Cannot parse number from " .. tostring(text)
+        else
+            return v
+        end
+    end,
     -- If returns false, input will not appear at all
     filter         = function(input)
         return input:match("[a-zA-Z]*")

--- a/example.lua
+++ b/example.lua
@@ -95,6 +95,19 @@ Prompt {
     end
 }:ask()
 
+Prompt {
+    prompt = "How many dogs did you pet today?",
+    parser = function(str)
+        local v = tonumber(str)
+        if not v then
+            return nil, "Cannot parse number from " .. tostring(str)
+        else
+            return v
+        end
+    end,
+    required = true,
+}:ask()
+
 List {
     prompt   = "How do you say 'Hello'?",
     required = true,


### PR DESCRIPTION
When using sirocco, I missed an easy way to parse a user's answer, eg. to a number. The `validator` comes very close, but it only indicates to the user whether their answer matches an expected format -- the validator can't actually change what is returned by `:ask()`. This PR lets the user set a `parser` to fill that gap.

Parsers work very similar to validators. Like validators, if the first return
value is not nil, it is considered that the current buffer is valid. Otherwise,
the second value is displayed as message under the prompt.

In contrast to validators, the parser can also transform the entered answer in a final
step before `:ask()` returns a value.

For example, this can be used to convert an answer to a number with a parser like this:

```lua
    local p = prompt {
      prompt = "How many dogs did you pet today?",
      parser = function(text)
        local v = tonumber(text)
        if not v then
          return nil, string.format("Cannot convert \"%s\" to a number", text)
        else
          return v
        end
      end,
    }
    local n_dogs = p:ask() -- n_dogs will be a number, or nil
```

In general, a parser is a function that takes the current answer as text, and
returns two values:

 - The first value is the parsed result. If this value is not nil, then it is
   assumed that the parser succesfully parsed the current answer.

 - The second value is a message that indicates why parsing failed, if
   applicable.

If a parser is defined, then `:ask()` will return the first result of the
parser.

Some design decisions I made along the way:

 - If both a parser and a validator are specified, then the parser takes
   precedence. I don't immediately see in which case you'd need both, so the
   precedence shouldn't matter that much.

 - When the user submits an invalid answer, `:ask()` will return `nil`, rather
   than the unparsed answer. This makes it easy to reason about the returned
   value from the caller's side: Whatever is returned by `:ask()` is always
   something the parser returned, and not arbitrary user input.

I tried to follow your coding style, and I'm of course open to any form of feedback or suggestions for changes.